### PR TITLE
feat: visualize wind vector with streamline

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from src.data import EXTRACTED_DIR, FILE_ID_MIN, to_filename
 from src.temporal import build_temporal_gui
 from src.vegetation import get_vegetation_actor
 from src.vtk_side_effects import import_for_rendering_core, import_for_rendering_volume
+from src.wind import get_wind_stream_actor
 from src.window import WINDOW_HEIGHT, WINDOW_WIDTH
 
 import_for_rendering_core()
@@ -47,6 +48,7 @@ temporal_spinbox.textChanged.connect(on_time_changed)
 
 renderer = vtkRenderer()
 renderer.AddActor(get_vegetation_actor(reader.GetOutputPort()))
+renderer.AddActor(get_wind_stream_actor(reader.GetOutputPort()))
 colors = vtkNamedColors()
 renderer.SetBackground(colors.GetColor3d("SlateGray"))  # type: ignore
 

--- a/src/wind.py
+++ b/src/wind.py
@@ -1,0 +1,33 @@
+from vtkmodules.vtkCommonExecutionModel import vtkAlgorithmOutput
+from vtkmodules.vtkCommonTransforms import vtkTransform
+from vtkmodules.vtkFiltersFlowPaths import vtkStreamTracer
+from vtkmodules.vtkFiltersGeneral import vtkTransformPolyDataFilter
+from vtkmodules.vtkFiltersSources import vtkPointSource
+from vtkmodules.vtkRenderingCore import vtkActor, vtkDataSetMapper
+
+
+def get_wind_stream_actor(port: vtkAlgorithmOutput):
+    seeds = vtkPointSource()
+    seeds.SetNumberOfPoints(100)
+
+    transform = vtkTransform()
+    transform.Translate(-90, 0, 140)
+    transform.Scale(250, 250, 250)
+
+    transformer = vtkTransformPolyDataFilter()
+    transformer.SetInputConnection(seeds.GetOutputPort())
+    transformer.SetTransform(transform)
+
+    streamline = vtkStreamTracer()
+    streamline.SetInputConnection(port)
+    streamline.SetSourceConnection(transformer.GetOutputPort())
+    streamline.SetMaximumPropagation(500)
+    streamline.SetIntegrationDirectionToBoth()
+
+    mapper = vtkDataSetMapper()
+    mapper.SetInputConnection(streamline.GetOutputPort())
+
+    actor = vtkActor()
+    actor.SetMapper(mapper)
+
+    return actor


### PR DESCRIPTION
Visualize wind vector field with stream tracer.

![image](https://user-images.githubusercontent.com/14951000/232262405-e36ac586-d584-41c0-a68a-bcf1cec982af.png)

The wind array is created during the extraction preprocess by combining `u`, `v`, and `w` arrays from the original dataset.